### PR TITLE
Removed the --@rostrap thing.

### DIFF
--- a/Ready.lua
+++ b/Ready.lua
@@ -2,7 +2,6 @@ local DEFAULT_TIMEOUT = 1 -- Length of time where no descendants have been added
 
 -- @author EmeraldSlash
 -- @repository https://github.com/EmeraldSlash/RbxReady
--- @rostrap Can be loaded using the Rostrap library manager
 
 local Ready = {}
 


### PR DESCRIPTION
Validark was complaining about it, since you don't actually need to put it in there since RoStrap does it automatically or something.